### PR TITLE
feat: trigger navigation on hover

### DIFF
--- a/__tests__/carousel.spec.tsx
+++ b/__tests__/carousel.spec.tsx
@@ -384,7 +384,7 @@ describe('<Carousel />', () => {
 
 		expect(navigationButton).not.toBeNull();
 
-		fireEvent.click(navigationButton!);
+		fireEvent.mouseOver(navigationButton!);
 		jest.runAllTimers();
 	});
 
@@ -403,14 +403,14 @@ describe('<Carousel />', () => {
 
 		expect(navigationButton).not.toBeNull();
 
-		fireEvent.click(navigationButton!);
+		fireEvent.mouseOver(navigationButton!);
 		jest.runAllTimers();
 
 		const leftButton = getByText('X');
 
 		expect(leftButton).not.toBeNull();
 
-		fireEvent.click(navigationButton!);
+		fireEvent.mouseOver(navigationButton!);
 		jest.runAllTimers();
 	});
 });

--- a/__tests__/navigation.spec.tsx
+++ b/__tests__/navigation.spec.tsx
@@ -30,7 +30,7 @@ describe('<Navigation />', () => {
 			<Navigation current={1} items={items} factory={factory} onClick={onClick} />,
 		);
 
-		fireEvent.click(getByText('selected'));
+		fireEvent.mouseOver(getByText('selected'));
 		expect(onClick).toHaveBeenCalled();
 	});
 });

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -11,7 +11,7 @@ export const Navigation: React.FC<NavigationProps> = ({
 	return (
 		<div className={styles.carouselNavigation}>
 			{items.map((_: any, i: number) => (
-				<div onClick={() => onClick(i)} key={i}>
+				<div onMouseOver={() => onClick(i)} key={i}>
 					{factory(current === i)}
 				</div>
 			))}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When navigation enabled, animations should trigger on `mouseOver` events of navigation thumbs.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
diff --git a/.github/workflows/PULL_REQUEST_TEMPLATE.md b/.github/workflows/PULL_REQUEST_TEMPLATE.md
