### PR TITLE
feat: add triggerClickOn prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+-   # [Carousel] triggerClickOn prop
+    Triggers onClick handlers of carousel items if swipe amount smaller than `triggerClickOn`.
+
+```jsx
+<Carousel triggerClickOn={5} />
+```
+
 -   # [Carousel] Navigation Thumbnail Feature
     Enables item to item navigation.
 

--- a/src/components/carousel/defaultProps.ts
+++ b/src/components/carousel/defaultProps.ts
@@ -19,4 +19,5 @@ export const defaultProps: Required<CarouselProps> = {
 	leftArrow: null,
 	autoSwipe: null,
 	navigation: null,
+	triggerClickOn: Number.MIN_SAFE_INTEGER,
 };

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -296,6 +296,7 @@ export interface CarouselProps {
 	rightArrow?: ReactElement | null;
 	autoSwipe?: number | null;
 	navigation?: null | ((selected: boolean) => ReactElement);
+	triggerClickOn?: number;
 }
 
 export interface CarouselState {

--- a/src/components/item/index.tsx
+++ b/src/components/item/index.tsx
@@ -75,7 +75,11 @@ export const ItemProvider: FunctionComponent<ItemProviderProps> = (
 			return;
 		}
 		const pos = getPageX(e);
-		setDrag({ ...drag, drag: drag.start - pos, pointers: false });
+		setDrag({
+			...drag,
+			drag: drag.start - pos,
+			pointers: Math.abs(drag.start - pos) < props.triggerClickOn,
+		});
 	};
 	const swipeProps = props.swiping
 		? {
@@ -129,4 +133,5 @@ export interface ItemProviderProps {
 	swipeOn: number;
 	responsive: boolean;
 	infinite: boolean;
+	triggerClickOn: number;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#### Adds triggerClickOn prop.
**Triggers onClick handlers of carousel items if swipe amount smaller than `triggerClickOn`.**

### Additional context

## Usage
```jsx
<Carousel triggerClickOn={5} />
```
if  `triggerClickOn` is **5**, when a user swipes lower than 5px  then pointer events of carousel item will be triggered.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
diff --git a/.github/workflows/PULL_REQUEST_TEMPLATE.md b/.github/workflows/PULL_REQUEST_TEMPLATE.md
