### PR TITLE
Remove reference to window to fix ssr error

### DIFF
--- a/src/components/scrolling-carousel/index.tsx
+++ b/src/components/scrolling-carousel/index.tsx
@@ -109,7 +109,7 @@ export const ScrollingCarousel: FunctionComponent<SliderProps> = ({
 	const smoothHorizontalScroll = (time: number, amount: number, start: number) => {
 		let curTime = 0;
 		for (let scrollCounter = 0; curTime <= time; scrollCounter++) {
-			window.setTimeout(
+			setTimeout(
 				smoothHorizontalScrollBehavior,
 				curTime,
 				(scrollCounter * amount) / 100 + start,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removes window reference in scrolling-carousel that breaks server side rendering during build when the component is used in Gatsby.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
diff --git a/.github/workflows/PULL_REQUEST_TEMPLATE.md b/.github/workflows/PULL_REQUEST_TEMPLATE.md
