### PR TITLE
we don't want to call `setState` after unmount.

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -258,3 +258,19 @@ export const getNavigationSlideAmount = (
 
 	return direction * -1;
 };
+
+export const setAbortableTimeout = (
+	callback: () => void,
+	delay: number,
+	signal: AbortSignal | undefined | null,
+) => {
+	const timer = setTimeout(() => {
+		signal?.removeEventListener('abort', handleAbort);
+		callback();
+	}, delay);
+
+	const handleAbort = () => {
+		clearTimeout(timer);
+	};
+	signal?.addEventListener('abort', handleAbort);
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We should cleanup all the async tasks after react unmounts the component otherwise this can potentially cause a memory leak.

### Additional context

I am not sure if this is a right solution in the case of react code. We could use a cancel token with `useRef` but this solution seemed more framework agnostic.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [] Other

### Before submitting the PR, please make sure you do the following
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
diff --git a/.github/workflows/PULL_REQUEST_TEMPLATE.md b/.github/workflows/PULL_REQUEST_TEMPLATE.md
