### PR TITLE
fix: Improving accessibility on buttons without any text

### DIFF
--- a/src/components/scrolling-carousel/index.tsx
+++ b/src/components/scrolling-carousel/index.tsx
@@ -133,7 +133,7 @@ export const ScrollingCarousel: FunctionComponent<SliderProps> = (
 	) => {
 		return (
 			<div data-arrow={data} onClick={() => slide(direction)}>
-				{element ?? <button />}
+				{element ?? <button aria-label={`${data === "right" ? "Sağa" : "Sola"} kaydır`} />}
 			</div>
 		);
 	};


### PR DESCRIPTION
Left and Right slider buttons doesn't have a text. So it is an accessibility issue. We can fix it by giving aria-label since screen-readers requires a text in button to be able to read

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
diff --git a/.github/workflows/PULL_REQUEST_TEMPLATE.md b/.github/workflows/PULL_REQUEST_TEMPLATE.md
