### PR TITLE
fix(carousel): implement auto slide without DOM focus interference

### DIFF
--- a/src/components/carousel/defaultProps.ts
+++ b/src/components/carousel/defaultProps.ts
@@ -22,5 +22,5 @@ export const defaultProps: Required<CarouselProps> = {
 	triggerClickOn: Number.MIN_SAFE_INTEGER,
 	hideArrows: false,
 	onLeftArrowClick: () => null,
-	onRightArrowClick: () => null
+	onRightArrowClick: () => null,
 };

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -55,7 +55,7 @@ export const Carousel: FunctionComponent<CarouselProps> = (userProps: CarouselPr
 	const [page, setPage] = useState<number>(0);
 	const isPaginating = useRef(false);
 	const slideButtonRef = useRef<HTMLDivElement>(null);
-	const autoSwipeTimer = useRef<number>();
+	const autoSwipeTimer = useRef<number>(0);
 	const isNavigation = typeof props.navigation === 'function';
 
 	if (props.dynamic) {
@@ -93,10 +93,8 @@ export const Carousel: FunctionComponent<CarouselProps> = (userProps: CarouselPr
 			typeof props.autoSwipe === 'number' &&
 			props.autoSwipe > props.transition
 		) {
-			autoSwipeTimer.current = setTimeout(() => {
-				if (slideButtonRef.current) {
-					slideButtonRef.current!.click();
-				}
+			autoSwipeTimer.current = window.setTimeout(() => {
+				slide(SlideDirection.Right);
 			}, props.autoSwipe);
 		}
 	};
@@ -254,18 +252,18 @@ export const Carousel: FunctionComponent<CarouselProps> = (userProps: CarouselPr
 	};
 
 	const onLeftArrowClick = () => {
-		slide(SlideDirection.Left)
+		slide(SlideDirection.Left);
 		if (props.onLeftArrowClick) {
 			props.onLeftArrowClick();
 		}
-	}
+	};
 
 	const onRightArrowClick = () => {
-		slide(SlideDirection.Right)
+		slide(SlideDirection.Right);
 		if (props.onRightArrowClick) {
 			props.onRightArrowClick();
 		}
-	}
+	};
 
 	return (
 		<div


### PR DESCRIPTION
Refactored the auto-swiping logic to remove the reliance on simulated button clicks using the `click` method.

 The updated implementation directly calls the `slide` function, preventing DOM focus issues and improving overall  accessibility of the carousel component & solved type problem